### PR TITLE
Update platform.ts

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -52,7 +52,7 @@ export class GreeACPlatform implements DynamicPlatformPlugin {
    * It should be used to setup event handlers for characteristics and update respective values.
    */
   configureAccessory(accessory: PlatformAccessory) {
-    this.log.info('Loading accessory from cache: ', accessory.displayName, accessory.context.device);
+    this.log.debug('Loading accessory from cache: ', accessory.displayName, accessory.context.device);
 
     // add the restored accessory to the accessories cache so we can track if it has already been registered
     if (accessory.context.device?.mac) {


### PR DESCRIPTION
Diagnostic data with accessory loaded from cache should appear on 'debug' log level only