### PR TITLE
Add two more settings 

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -94,6 +94,25 @@
               "maximum": 30,
               "default": 30
             },
+            "targetTemperatureStep": {
+              "type": "number",
+              "required": true,
+              "default": 1,
+              "oneOf": [
+                {
+                  "title": "1 degree",
+                  "enum": [
+                    1.0
+                  ]
+                },
+                {
+                  "title": "0.5 degree",
+                  "enum": [
+                    0.5
+                  ]
+                }
+              ]
+            },
             "xFanEnabled": {
               "type": "boolean",
               "default": false
@@ -320,14 +339,14 @@
               }
             },
             {
-              "key": "devices[].xFanEnabled",
+              "key": "devices[].targetTemperatureStep",
               "flex": "1 1 50%",
-              "title": "xFan enabled",
-              "description": "If enabled, then xFan functionality is turned on automatically on the device",
+              "title": "Target temperature step:",
+              "description": "Temperature increments value",
               "condition": {
                 "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true);"
               }
-            },
+            }, 
             {
               "key": "devices[].temperatureSensor",
               "flex": "1 1 50%",
@@ -350,9 +369,18 @@
               "key": "devices[].defaultVerticalSwing",
               "flex": "1 1 50%",
               "title": "Vertical position:",
-              "description": "Default vertical swing position to be used istead of what device considers a default",
+              "description": "Default vertical swing position to be used instead of what device considers a default",
               "condition": {
                 "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true && model.devices[arrayIndices].overrideDefaultVerticalSwing !== 0);"
+              }
+            },
+            {
+              "key": "devices[].xFanEnabled",
+              "flex": "1 1 50%",
+              "title": "xFan enabled",
+              "description": "If enabled, then xFan functionality is turned on automatically on the device",
+              "condition": {
+                "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true);"
               }
             }
           ]

--- a/config.schema.json
+++ b/config.schema.json
@@ -125,6 +125,74 @@
             },
             "disabled": {
               "type": "boolean"
+            },
+            "overrideDefaultVerticalSwing": {
+              "type": "integer",
+              "required": true,
+              "default": 0,
+              "oneOf": [
+                {
+                  "title": "Never",
+                  "enum": [
+                      0
+                  ]
+                },
+                {
+                  "title": "After power on",
+                  "enum": [
+                      1
+                  ]
+                },
+                {
+                  "title": "After power on and swing disable",
+                  "enum": [
+                      2
+                  ]
+                }
+              ]
+            },
+            "defaultVerticalSwing":{
+              "type": "integer",
+              "required": false,
+              "default": 2,
+              "oneOf": [
+                {
+                  "title": "Swing",
+                  "enum": [
+                    1
+                  ]
+                },
+                {
+                  "title": "Highest",
+                  "enum": [
+                    2
+                  ]
+                },
+                {
+                  "title": "Higher",
+                  "enum": [
+                    3
+                  ]
+                },
+                {
+                  "title": "Middle",
+                  "enum": [
+                    4
+                  ]
+                },
+                {
+                  "title": "Lower",
+                  "enum": [
+                    5
+                  ]
+                },
+                {
+                  "title": "Lowest",
+                  "enum": [
+                    6
+                  ]
+                }
+              ]
             }
           }
         }
@@ -267,6 +335,24 @@
               "description": "Additional temperature sensor in Home App",
               "condition": {
                 "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true);"
+              }
+            },
+            {
+              "key": "devices[].overrideDefaultVerticalSwing",
+              "flex": "1 1 50%",
+              "title": "Override default vertical position:",
+              "description": "When to override vertical swing position",
+              "condition": {
+                "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true);"
+              }
+            },
+            {
+              "key": "devices[].defaultVerticalSwing",
+              "flex": "1 1 50%",
+              "title": "Vertical position:",
+              "description": "Default vertical swing position to be used istead of what device considers a default",
+              "condition": {
+                "functionBody": "return (model.devices && model.devices[arrayIndices] && model.devices[arrayIndices].mac && /^[a-f0-9]{12}$/.test(model.devices[arrayIndices].mac) && model.devices[arrayIndices].disabled !== true && model.devices[arrayIndices].overrideDefaultVerticalSwing !== 0);"
               }
             }
           ]

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -95,14 +95,14 @@ export class GreeAirConditioner {
     // register handlers for the Cooling Threshold Temperature Characteristic
     // (minValue and maxValue can't be set here, they need an active accessory in cooling sate to set)
     this.HeaterCooler.getCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature)
-      .setProps({ minStep: 0.5 })
+      .setProps({ minStep: this.deviceConfig.targetTemperatureStep })
       .onGet(this.getTargetTemperature.bind(this, 'CoolingThresholdTemperature'))
       .onSet(this.setTargetTemperature.bind(this));
 
     // register handlers for the Heating Threshold Temperature Characteristic
     // (minValue and maxValue can't be set here, they need an active accessory in heating sate to set)
     this.HeaterCooler.getCharacteristic(this.platform.Characteristic.HeatingThresholdTemperature)
-      .setProps({ minStep: 0.5 })
+      .setProps({ minStep: this.deviceConfig.targetTemperatureStep })
       .onGet(this.getTargetTemperature.bind(this, 'HeatingThresholdTemperature'))
       .onSet(this.setTargetTemperature.bind(this));
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export interface DeviceConfig {
   sensorOffset: number;
   minimumTargetTemperature: number;
   maximumTargetTemperature: number;
+  targetTemperatureStep: number;
   xFanEnabled: boolean;
   temperatureSensor: string;
   disabled?: boolean;
@@ -29,6 +30,7 @@ export const DEFAULT_DEVICE_CONFIG: DeviceConfig = {
   sensorOffset: 40,
   minimumTargetTemperature: 16,
   maximumTargetTemperature: 30,
+  targetTemperatureStep: 1.0,
   xFanEnabled: true,
   temperatureSensor: 'disabled',
   defaultVerticalSwing: 1,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -19,6 +19,8 @@ export interface DeviceConfig {
   xFanEnabled: boolean;
   temperatureSensor: string;
   disabled?: boolean;
+  defaultVerticalSwing: number;
+  overrideDefaultVerticalSwing: number;
 }
 
 export const DEFAULT_DEVICE_CONFIG: DeviceConfig = {
@@ -29,6 +31,8 @@ export const DEFAULT_DEVICE_CONFIG: DeviceConfig = {
   maximumTargetTemperature: 30,
   xFanEnabled: true,
   temperatureSensor: 'disabled',
+  defaultVerticalSwing: 1,
+  overrideDefaultVerticalSwing: 0
 };
 
 export const UDP_SCAN_PORT = 7000;
@@ -63,3 +67,9 @@ export const TEMPERATURE_TABLE = {
 };
 
 export const INIT_TEMP_TRESHOLD_TIMEOUT = 100;
+
+export const OVERRIDE_DEFAULT_SWING = {
+    never: 0,
+    powerOn: 1,
+    always: 2
+};


### PR DESCRIPTION
Hi @eibenp ,
I like your minimalistic approach to controlling AC units as having a single accessory is easy to explain to family members ;). I found a couple of small issues that were bothering me and I fixed/modified them in my fork. 
By no means I plan to publish another version of this plugin to Homebridge repository.
So, if you think my changes fit into your vision of this plugin, then feel free to review my code, give remarks if you have them, and we can merge it.
If you think these changes are too much, then I have no problem if you decline it, and I will maintain it as a fork for my own needs.

There are two main changes.
1. I added target temperature step as a configurable option. I understand it may work well on some devices, but in my case devices never accepted halves of degree, and Home app and the actual device became unsynchronized. For example target temperature is 20 degrees. I change it to 20.5 (on purpose, or accidentally) and Home app „thinks” it’s set to 20.5, but there is no beep sound coming from the AC unit, and during the next status update Home app resets to 20 degrees. It’s not a deal breaker, but definitely a poor user experience. Hence the option, to use whole degrees or halves of degree as a step.
2.  That’s a bit more complicated. I notice that all of my Gree devices, and I have in total 5 of them of 2 different models, tend to reset vertical swing position to default on power on from the app, if it was set to any fixed position. I tried original Gree app, this plugin, kongkx’s plugin. In the Gree app I can see, that the previous fixed position is still set, but devices behave like it wasn’t set and move vertical air guide to the default position (in my case all the way up in cooling mode, and all the way down in heating mode). 
This doesn’t happen when operating from remote controller, most likely because it sends all settings even if only one was changed. And this behavior is also fixed/mocked in my fork.
There is a setting to set fixed position of vertical guide if current setting is default. The same setting enforces to reset current vertical position if it’s different then default. So it won’t override different fixed position if it was set from remote or Gree app. Default position overriding can be set to actual do it’s job during power on/mode change or additionally after turning of vertical swing mode.


